### PR TITLE
Implement privilege saga using Kafka

### DIFF
--- a/backend/tasks-service/build.gradle.kts
+++ b/backend/tasks-service/build.gradle.kts
@@ -14,7 +14,6 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/backend/tasks-service/build.gradle.kts
+++ b/backend/tasks-service/build.gradle.kts
@@ -18,9 +18,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.kafka:spring-kafka")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("org.postgresql:postgresql")
     implementation("org.liquibase:liquibase-core")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/backend/tasks-service/src/main/kotlin/com/example/tasksservice/config/KafkaConfig.kt
+++ b/backend/tasks-service/src/main/kotlin/com/example/tasksservice/config/KafkaConfig.kt
@@ -1,0 +1,42 @@
+package com.example.tasksservice.config
+
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.ProducerFactory
+import com.example.tasksservice.service.PrivilegeSaga.PrivilegeRequest
+import com.example.tasksservice.service.PrivilegeSaga.PrivilegeResponse
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.core.*
+import org.springframework.kafka.requestreply.ReplyingKafkaTemplate
+import org.springframework.kafka.listener.KafkaMessageListenerContainer
+import org.springframework.kafka.listener.ContainerProperties
+
+@Configuration
+@EnableKafka
+class KafkaConfig(private val properties: KafkaProperties) {
+
+    @Bean
+    fun producerFactory(): ProducerFactory<String, PrivilegeRequest> =
+        DefaultKafkaProducerFactory(properties.buildProducerProperties())
+
+    @Bean
+    fun consumerFactory(): ConsumerFactory<String, PrivilegeResponse> =
+        DefaultKafkaConsumerFactory(properties.buildConsumerProperties())
+
+    @Bean
+    fun repliesContainer(cf: ConsumerFactory<String, PrivilegeResponse>): KafkaMessageListenerContainer<String, PrivilegeResponse> {
+        val containerProps = ContainerProperties("privilege.responses")
+        return KafkaMessageListenerContainer(cf, containerProps)
+    }
+
+    @Bean
+    fun replyingKafkaTemplate(
+        pf: ProducerFactory<String, PrivilegeRequest>,
+        repliesContainer: KafkaMessageListenerContainer<String, PrivilegeResponse>
+    ): ReplyingKafkaTemplate<String, PrivilegeRequest, PrivilegeResponse> = ReplyingKafkaTemplate(pf, repliesContainer)
+
+    @Bean
+    fun kafkaTemplate(pf: ProducerFactory<String, PrivilegeRequest>): KafkaTemplate<String, PrivilegeRequest> = KafkaTemplate(pf)
+}

--- a/backend/tasks-service/src/main/kotlin/com/example/tasksservice/config/KafkaConfig.kt
+++ b/backend/tasks-service/src/main/kotlin/com/example/tasksservice/config/KafkaConfig.kt
@@ -27,7 +27,9 @@ class KafkaConfig(private val properties: KafkaProperties) {
 
     @Bean
     fun repliesContainer(cf: ConsumerFactory<String, PrivilegeResponse>): KafkaMessageListenerContainer<String, PrivilegeResponse> {
-        val containerProps = ContainerProperties("privilege.responses")
+        val containerProps = ContainerProperties("privilege.responses").apply {
+            groupId = "tasks-service"
+        }
         return KafkaMessageListenerContainer(cf, containerProps)
     }
 

--- a/backend/tasks-service/src/main/kotlin/com/example/tasksservice/config/SecurityConfig.kt
+++ b/backend/tasks-service/src/main/kotlin/com/example/tasksservice/config/SecurityConfig.kt
@@ -9,7 +9,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.authentication.AuthenticationProvider
-import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
@@ -45,6 +44,4 @@ class SecurityConfig(private val authProvider: AuthenticationProvider) {
         return source
     }
 
-    @Bean
-    fun webClient(builder: WebClient.Builder): WebClient = builder.build()
 }

--- a/backend/tasks-service/src/main/kotlin/com/example/tasksservice/controller/TaskController.kt
+++ b/backend/tasks-service/src/main/kotlin/com/example/tasksservice/controller/TaskController.kt
@@ -12,20 +12,20 @@ import org.springframework.web.bind.annotation.*
 class TaskController(private val taskRepository: TaskRepository) {
 
     @GetMapping
-    @PreAuthorize("hasAuthority('TASK')")
+    @PreAuthorize("@privilegeSaga.hasTaskPrivilege(authentication)")
     fun all(): List<Task> = taskRepository.findAll()
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAuthority('TASK')")
+    @PreAuthorize("@privilegeSaga.hasTaskPrivilege(authentication)")
     fun one(@PathVariable id: UUID): Task = taskRepository.findById(id).orElseThrow()
 
     @PostMapping
-    @PreAuthorize("hasAuthority('TASK')")
+    @PreAuthorize("@privilegeSaga.hasTaskPrivilege(authentication)")
     @ResponseStatus(HttpStatus.CREATED)
     fun create(@RequestBody task: Task): Task = taskRepository.save(task)
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAuthority('TASK')")
+    @PreAuthorize("@privilegeSaga.hasTaskPrivilege(authentication)")
     fun update(@PathVariable id: UUID, @RequestBody updated: Task): Task {
         val existing = taskRepository.findById(id).orElseThrow()
         val task = existing.copy(description = updated.description, completed = updated.completed, userId = updated.userId)
@@ -33,7 +33,7 @@ class TaskController(private val taskRepository: TaskRepository) {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAuthority('TASK')")
+    @PreAuthorize("@privilegeSaga.hasTaskPrivilege(authentication)")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun delete(@PathVariable id: UUID) {
         taskRepository.deleteById(id)

--- a/backend/tasks-service/src/main/kotlin/com/example/tasksservice/security/RemoteAuthProvider.kt
+++ b/backend/tasks-service/src/main/kotlin/com/example/tasksservice/security/RemoteAuthProvider.kt
@@ -7,27 +7,33 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.springframework.kafka.requestreply.ReplyingKafkaTemplate
+import org.springframework.kafka.support.KafkaHeaders
+import com.example.tasksservice.service.PrivilegeSaga.PrivilegeRequest
+import com.example.tasksservice.service.PrivilegeSaga.PrivilegeResponse
 
 @Component
-class RemoteAuthProvider(private val webClient: WebClient) : AuthenticationProvider {
-    data class Role(val name: String)
-    data class UserResponse(val username: String, val roles: List<Role>)
+class RemoteAuthProvider(
+    private val kafka: ReplyingKafkaTemplate<String, PrivilegeRequest, PrivilegeResponse>
+) : AuthenticationProvider {
 
     override fun authenticate(authentication: Authentication): Authentication {
         val username = authentication.name
         val password = authentication.credentials.toString()
-        try {
-            val user = webClient.get()
-                .uri("http://user-service:8081/api/me")
-                .headers { it.setBasicAuth(username, password) }
-                .retrieve()
-                .bodyToMono(UserResponse::class.java)
-                .block() ?: throw BadCredentialsException("Bad credentials")
-            val authorities = user.roles.map { SimpleGrantedAuthority(it.name) }
-            return UsernamePasswordAuthenticationToken(username, password, authorities)
-        } catch (ex: WebClientResponseException) {
+        val request = PrivilegeRequest(username, password)
+        val record = ProducerRecord<String, PrivilegeRequest>("privilege.requests", request).apply {
+            headers().add(RecordHeader(KafkaHeaders.REPLY_TOPIC, "privilege.responses".toByteArray()))
+        }
+        return try {
+            val response = kafka.sendAndReceive(record).get(5, java.util.concurrent.TimeUnit.SECONDS).value()
+            if (response.roles.isEmpty()) {
+                throw BadCredentialsException("Bad credentials")
+            }
+            val authorities = response.roles.map { SimpleGrantedAuthority(it) }
+            UsernamePasswordAuthenticationToken(username, password, authorities)
+        } catch (ex: Exception) {
             throw BadCredentialsException("Bad credentials")
         }
     }

--- a/backend/tasks-service/src/main/kotlin/com/example/tasksservice/service/PrivilegeSaga.kt
+++ b/backend/tasks-service/src/main/kotlin/com/example/tasksservice/service/PrivilegeSaga.kt
@@ -1,0 +1,28 @@
+package com.example.tasksservice.service
+
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.springframework.kafka.requestreply.ReplyingKafkaTemplate
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component("privilegeSaga")
+class PrivilegeSaga(
+    private val kafka: ReplyingKafkaTemplate<String, PrivilegeRequest, PrivilegeResponse>
+) {
+    data class PrivilegeRequest(val username: String, val password: String)
+    data class PrivilegeResponse(val roles: List<String>)
+
+    fun hasTaskPrivilege(auth: Authentication): Boolean {
+        val request = PrivilegeRequest(auth.name, auth.credentials.toString())
+        val record = ProducerRecord<String, PrivilegeRequest>("privilege.requests", request).apply {
+            headers().add(RecordHeader(KafkaHeaders.REPLY_TOPIC, "privilege.responses".toByteArray()))
+        }
+        val future = kafka.sendAndReceive(record)
+        val result = future.get(5, TimeUnit.SECONDS)
+        val response = result.value()
+        return response.roles.contains("TASK")
+    }
+}

--- a/backend/tasks-service/src/main/resources/application.yml
+++ b/backend/tasks-service/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
 
+  kafka:
+    bootstrap-servers: kafka:9092
+    consumer:
+      auto-offset-reset: earliest
+
 server:
   port: 8082
 

--- a/backend/user-service/build.gradle.kts
+++ b/backend/user-service/build.gradle.kts
@@ -18,9 +18,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.kafka:spring-kafka")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("org.postgresql:postgresql")
     implementation("org.liquibase:liquibase-core")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/backend/user-service/src/main/kotlin/com/example/userservice/config/KafkaConfig.kt
+++ b/backend/user-service/src/main/kotlin/com/example/userservice/config/KafkaConfig.kt
@@ -1,0 +1,34 @@
+package com.example.userservice.config
+
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.*
+import org.springframework.kafka.annotation.EnableKafka
+
+@Configuration
+@EnableKafka
+class KafkaConfig(private val properties: KafkaProperties) {
+
+    @Bean
+    fun producerFactory(): ProducerFactory<String, Any> =
+        DefaultKafkaProducerFactory(properties.buildProducerProperties())
+
+    @Bean
+    fun consumerFactory(): ConsumerFactory<String, Any> =
+        DefaultKafkaConsumerFactory(properties.buildConsumerProperties())
+
+    @Bean
+    fun kafkaTemplate(pf: ProducerFactory<String, Any>): KafkaTemplate<String, Any> =
+        KafkaTemplate(pf)
+
+    @Bean
+    fun kafkaListenerContainerFactory(cf: ConsumerFactory<String, Any>): ConcurrentKafkaListenerContainerFactory<String, Any> {
+        val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
+        factory.consumerFactory = cf
+        return factory
+    }
+}

--- a/backend/user-service/src/main/kotlin/com/example/userservice/config/KafkaConfig.kt
+++ b/backend/user-service/src/main/kotlin/com/example/userservice/config/KafkaConfig.kt
@@ -26,9 +26,13 @@ class KafkaConfig(private val properties: KafkaProperties) {
         KafkaTemplate(pf)
 
     @Bean
-    fun kafkaListenerContainerFactory(cf: ConsumerFactory<String, Any>): ConcurrentKafkaListenerContainerFactory<String, Any> {
+    fun kafkaListenerContainerFactory(
+        cf: ConsumerFactory<String, Any>,
+        kt: KafkaTemplate<String, Any>
+    ): ConcurrentKafkaListenerContainerFactory<String, Any> {
         val factory = ConcurrentKafkaListenerContainerFactory<String, Any>()
         factory.consumerFactory = cf
+        factory.setReplyTemplate(kt)
         return factory
     }
 }

--- a/backend/user-service/src/main/kotlin/com/example/userservice/service/PrivilegeListener.kt
+++ b/backend/user-service/src/main/kotlin/com/example/userservice/service/PrivilegeListener.kt
@@ -1,0 +1,28 @@
+package com.example.userservice.service
+
+import com.example.userservice.repository.UserRepository
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Component
+
+@Component
+class PrivilegeListener(
+    private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder
+) {
+    data class PrivilegeRequest(val username: String, val password: String)
+    data class PrivilegeResponse(val roles: List<String>)
+
+    @KafkaListener(topics = ["privilege.requests"], groupId = "user-service")
+    @SendTo("privilege.responses")
+    fun handle(request: PrivilegeRequest): PrivilegeResponse {
+        val user = userRepository.findByUsername(request.username).orElse(null)
+            ?: return PrivilegeResponse(emptyList())
+        return if (passwordEncoder.matches(request.password, user.password)) {
+            PrivilegeResponse(user.roles.map { it.name })
+        } else {
+            PrivilegeResponse(emptyList())
+        }
+    }
+}

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
 
+  kafka:
+    bootstrap-servers: kafka:9092
+    consumer:
+      auto-offset-reset: earliest
+
 server:
   port: 8081
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,22 @@ services:
       - "8082:8082"
     depends_on:
       - task-db
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    ports:
+      - "9092:9092"
   frontend:
     build: ./frontend
     ports:


### PR DESCRIPTION
## Summary
- add `KafkaConfig` beans to both services
- implement `PrivilegeSaga` with request/reply via Kafka
- handle privilege requests in user service with `PrivilegeListener`
- configure Kafka in application settings and compose file

## Testing
- `gradle test` in `backend/tasks-service`
- `gradle test` in `backend/user-service`


------
https://chatgpt.com/codex/tasks/task_e_6857312225e0832b9f36164feef5a196